### PR TITLE
Separate HOST from PORT in the env configuration

### DIFF
--- a/cmd/netobserv-agent.go
+++ b/cmd/netobserv-agent.go
@@ -26,11 +26,20 @@ func main() {
 
 	logrus.SetLevel(logrus.DebugLevel)
 	// temporary hack until NETOBSERV-201
-	flowsTarget := os.Getenv("FLOWS_TARGET")
-	if flowsTarget == "" {
-		panic("expecting a collector target in the FLOWS_TARGET env var")
+	flowsTargetHost := os.Getenv("FLOWS_TARGET_HOST")
+	if flowsTargetHost == "" {
+		panic("expecting a collector target in the FLOWS_TARGET_HOST env var")
 	}
-	logrus.WithField("FLOWS_TARGET", flowsTarget).Infof("Starting eBFP flows' agent")
+	flowsTargetPort := os.Getenv("FLOWS_TARGET_PORT")
+	if flowsTargetPort == "" {
+		panic("expecting a collector target in the FLOWS_TARGET_PORT env var")
+	}
+	logrus.WithFields(logrus.Fields{
+		"FLOWS_TARGET_HOST": flowsTargetHost,
+		"FLOWS_TARGET_PORT": flowsTargetPort,
+	}).Infof("Starting eBFP flows' agent")
+
+	flowsTarget := flowsTargetHost + ":" + flowsTargetPort
 
 	flowsAgent, err := agent.FlowsAgent(&agent.Config{
 		FlowsTarget:        flowsTarget,

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,10 @@
+# Deployment example files
+
+This directory contains some example files that show how the netobserv-agent
+can be deployed. In production, the agent is deployed by the Network Observability Operator
+but the files contained here are useful for documentation and manual testing.
+
+* `flp-daemonset.yml`, shows how to deploy/configure the Agent when Flowlogs Pipeline is deployed
+  as daemonset, taking the target host configuration from the Host IP.
+* `flp-service.yml`, shows how to deploy/configure the Agent when Flowlogs Pipeline is deployed
+  as a service, explicitly setting the host configuration as the service name.

--- a/deployments/flp-daemonset.yml
+++ b/deployments/flp-daemonset.yml
@@ -1,0 +1,141 @@
+# Example deployment for manual testing with flp
+# It requires loki to be installed
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netobserv-agent
+  labels:
+    k8s-app: netobserv-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: netobserv-agent
+  template:
+    metadata:
+      labels:
+        k8s-app: netobserv-agent
+    spec:
+      serviceAccountName: netobserv-account
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: netobserv-agent
+        image: quay.io/mmaciasl/netobserv-agent:main
+        #      imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+          - name: FLOWS_TARGET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: FLOWS_TARGET_PORT
+            value: "9999"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: flp
+  labels:
+    k8s-app: flp
+spec:
+  selector:
+    matchLabels:
+      k8s-app: flp
+  template:
+    metadata:
+      labels:
+        k8s-app: flp
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: netobserv-controller-manager
+      containers:
+        - name: packet-counter
+          image: quay.io/mmaciasl/flowlogs-pipeline:latest
+          ports:
+            - containerPort: 9999
+          args:
+            - --config=/etc/flp/config.yaml
+          volumeMounts:
+            - mountPath: /etc/flp
+              name: config-volume
+      volumes:
+        - name: config-volume
+          configMap:
+            name: flp-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flp-config
+data:
+  config.yaml: |
+    log-level: debug
+    pipeline:
+      - name: ingest
+      - name: decode
+        follows: ingest
+      - name: enrich
+        follows: decode
+      - name: encode
+        follows: enrich
+      - name: loki
+        follows: encode
+    parameters:
+      - name: ingest
+        ingest:
+          type: grpc
+          grpc:
+            port: 9999
+      - name: decode
+        decode:
+          type: protobuf
+      - name: enrich
+        transform:
+          type: network
+          network:
+            rules:
+              - input: SrcAddr
+                output: SrcK8S
+                type: "add_kubernetes"
+              - input: DstAddr
+                output: DstK8S
+                type: "add_kubernetes"
+      - name: encode
+        encode:
+          type: none
+      - name: loki
+        write:
+          type: loki
+          loki:
+            type: loki
+            staticLabels:
+              app: netobserv-flowcollector
+            labels:
+              - "SrcK8S_Namespace"
+              - "SrcK8S_OwnerName"
+              - "DstK8S_Namespace"
+              - "DstK8S_OwnerName"
+              - "FlowDirection"
+            url: http://loki:3100
+            timestampLabel: TimeFlowEnd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netobserv-account
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: example
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostPorts: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+  - system:serviceaccount:network-observability:netobserv-account

--- a/deployments/flp-service.yml
+++ b/deployments/flp-service.yml
@@ -1,0 +1,155 @@
+# Example deployment for manual testing with flp
+# It requires loki to be installed
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netobserv-agent
+  labels:
+    k8s-app: netobserv-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: netobserv-agent
+  template:
+    metadata:
+      labels:
+        k8s-app: netobserv-agent
+    spec:
+      serviceAccountName: netobserv-account
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: netobserv-agent
+        image: quay.io/mmaciasl/netobserv-agent:main
+        #      imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+          - name: FLOWS_TARGET_HOST
+            value: "flp"
+          - name: FLOWS_TARGET_PORT
+            value: "9999"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flp
+  labels:
+    k8s-app: flp
+spec:
+  ports:
+    - port: 9999
+      protocol: TCP
+      targetPort: 9999
+      name: flp
+  selector:
+    k8s-app: flp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flp
+  labels:
+    k8s-app: flp
+spec:
+  selector:
+    matchLabels:
+      k8s-app: flp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: flp
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: netobserv-controller-manager
+      containers:
+        - name: packet-counter
+          image: quay.io/mmaciasl/flowlogs-pipeline:latest
+          ports:
+            - containerPort: 9999
+          args:
+            - --config=/etc/flp/config.yaml
+          volumeMounts:
+            - mountPath: /etc/flp
+              name: config-volume
+      volumes:
+        - name: config-volume
+          configMap:
+            name: flp-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flp-config
+data:
+  config.yaml: |
+    log-level: debug
+    pipeline:
+      - name: ingest
+      - name: decode
+        follows: ingest
+      - name: enrich
+        follows: decode
+      - name: encode
+        follows: enrich
+      - name: loki
+        follows: encode
+    parameters:
+      - name: ingest
+        ingest:
+          type: grpc
+          grpc:
+            port: 9999
+      - name: decode
+        decode:
+          type: protobuf
+      - name: enrich
+        transform:
+          type: network
+          network:
+            rules:
+              - input: SrcAddr
+                output: SrcK8S
+                type: "add_kubernetes"
+              - input: DstAddr
+                output: DstK8S
+                type: "add_kubernetes"
+      - name: encode
+        encode:
+          type: none
+      - name: loki
+        write:
+          type: loki
+          loki:
+            type: loki
+            staticLabels:
+              app: netobserv-flowcollector
+            labels:
+              - "SrcK8S_Namespace"
+              - "SrcK8S_OwnerName"
+              - "DstK8S_Namespace"
+              - "DstK8S_OwnerName"
+              - "FlowDirection"
+            url: http://loki:3100
+            timestampLabel: TimeFlowEnd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netobserv-account
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: example
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostPorts: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+  - system:serviceaccount:network-observability:netobserv-account

--- a/examples/performance/deployment.yml
+++ b/examples/performance/deployment.yml
@@ -56,7 +56,7 @@ spec:
           topologyKey: kubernetes.io/hostname
   containers:
     - name: netobserv-agent
-      image: quay.io/mmaciasl/netobserv-agent:main
+      image: quay.io/netobserv/netobserv-agent:main
 #      imagePullPolicy: Always
       securityContext:
         privileged: true
@@ -69,7 +69,6 @@ spec:
           value: "ares"
         - name: FLOWS_TARGET
           value: "packet-counter:9999"
-      resources:
-        limits:
-          # increase or comment this to avoid limits in the number of processed packets
-          cpu: "1000m"
+#      resources:
+#        limits:
+#          cpu: "1000m"


### PR DESCRIPTION
This will facilitate setting the Node IP in the descriptor when the
flowlogs-pipeline is deployed as daemonset.

it also includes two deployment descriptors for manual testing